### PR TITLE
Renaming old titles and pages

### DIFF
--- a/documentation/docs/system-architecture/Design.md
+++ b/documentation/docs/system-architecture/Design.md
@@ -24,7 +24,7 @@ Feedstack's architecture is divided into three primary areas:
 2. **Backend Services:** The core processing layer that handles file uploads, communicates with external analysis tools, and categorizes the feedback.
 3. **External Services:** Integrations with OpenAI’s GPT-4 Vision API for design analysis and Firebase for secure storage.
 
-### 2.1 System Components and Interfaces
+### System Components and Interfaces
 
 #### **Client Application (Frontend - React)**
 The frontend provides a streamlined interface where users can interact with the system efficiently.
@@ -113,14 +113,14 @@ Feedstack integrates external tools to enhance its functionality.
 
 - Visualizes how the user can upload their design into Feedstack. In this scenario, the user begins from the login screen and works their way into the file upload destination that's housed in the dashboard. This diagram also shows how the file uploading errors will be handled. 
 
-### Use Case 4: Navigating Feedback Using Bookmarks
+### Use Case: Navigating Feedback Using Bookmarks
 ![Seq4_Use4_ProjectsInCS](https://github.com/user-attachments/assets/4934b33f-ba97-4852-a2b9-0232347b0ea8)
 
 - Shows how a user can navigate to the feedback of their uploaded document. This diagram skips over the login and file upload processes, and begins right after the system returns it's intial feedback. 
 
 ---
 
-## 4. Simple Class Diagram
+## Simple Class Diagram
 
 ![diagram-9](https://github.com/user-attachments/assets/a00cd152-2587-420c-9520-c8450133abc3)
 

--- a/documentation/docs/system-architecture/ER Diagrams.md
+++ b/documentation/docs/system-architecture/ER Diagrams.md
@@ -2,7 +2,7 @@
 sidebar_position: 8
 ---
 
-## 5. Database Design and ERD
+## Database Design and Entity Relationship Diagrams 
 ![diagram-7](https://github.com/user-attachments/assets/f0f789e2-c525-475d-9650-d301cfc34ac8)
 Feedstack's database structure is designed to streamline user interactions, design uploads, and AI-driven feedback. Users can upload their designs, which are stored in the DESIGNUPLOADS table, linking each design to its uploader. Feedback on these designs is captured in the FEEDBACK table, allowing users to provide comments and ratings. To enhance organization, feedback is categorized under predefined THEMECATEGORIES, ensuring insights align with key visual design principles. Additionally, KEYWORDS help analyze and relate uploaded designs to relevant themes. This setup keeps everything structured, making it easy to track, categorize, and improve design feedback.
 


### PR DESCRIPTION
Old titles that have numbers that are no longer needed with the new setup of the documentation with multiple pages